### PR TITLE
feat/cimd-flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,19 @@
 
 This repository demonstrates how to secure a Model Context Protocol (MCP) server using OAuth 2.1 authorization flows, implemented entirely with Node.js and Express.js. While this example uses AWS Cognito as the backing authorization server, the implementation is **provider-agnostic** and can work with any OAuth 2.1 compliant authorization server.
 
-Based on the MCP Authorization Specification (version 2025-06-18), this project showcases:
+Based on the MCP Authorization Specification (version 2025-11-25), this project showcases:
 - MCP server acting as a **Resource Server** (RS) with generic OAuth endpoints
 - Provider-agnostic OAuth 2.1 implementation (example uses AWS Cognito)
 - OAuth 2.1 Authorization Code Flow with PKCE and RFC 8707 Resource Indicators
 - Protected Resource Metadata (PRM) document discovery
 - **Fully dynamic** authorization server metadata discovery
 - Dynamic Client Registration (DCR) support
-- Enhanced security features from MCP 2025-06-18 specification
-- Two client implementations:
+- Client ID Metadata Documents (CIMD) support
+- Enhanced security features from MCP 2025-11-25 specification
+- Three client implementations:
   - Static client with pre-configured credentials
-  - Auto-discovery client with dynamic registration
+  - Auto-discovery client with dynamic registration (DCR)
+  - Metadata client using Client ID Metadata Documents (CIMD)
 
 ## Provider-Agnostic Design
 
@@ -45,13 +47,23 @@ Key components of the specification:
    - Bearer token usage for authenticated requests
    - Dynamic token validation using discovered JWKS URIs and issuer information
 
-4. **Dynamic Client Registration (DCR)**
+4. **Client Registration Priority** (MCP 2025-11-25)
+   - **Pre-registered** client credentials (if available for the server)
+   - **Client ID Metadata Documents** (if authorization server advertises `client_id_metadata_document_supported: true`)
+   - **Dynamic Client Registration** (RFC7591 fallback)
+   - Prompt user for manual configuration (last resort)
+
+5. **Dynamic Client Registration (DCR)**
    - Allows clients to automatically register with new MCP servers
    - Eliminates the need for manual client registration processes
-   - Enables seamless discovery and connection to new services
-   - MCP specification strongly recommends implementing DCR since "clients do not know the set of MCP servers in advance"
-   - Provides a standardized way to obtain OAuth client credentials
    - Follows RFC7591 (OAuth 2.0 Dynamic Client Registration Protocol)
+
+6. **Client ID Metadata Documents (CIMD)**
+   - Client publishes its OAuth metadata at an HTTPS URL
+   - The URL itself becomes the `client_id`
+   - Authorization server fetches and validates the metadata document
+   - No pre-registration or database storage required
+   - Follows [draft-ietf-oauth-client-id-metadata-document](https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document)
 
 This implementation showcases how to apply these concepts in a provider-agnostic way. The example uses AWS Cognito with custom Dynamic Client Registration through API Gateway endpoints and Lambda functions, but the core OAuth flow works with any compliant authorization server.
 
@@ -73,6 +85,7 @@ Diagrams:
 - [Architecture Diagram](./docs/mcp-oauth-architecture.mermaid)
 - [Sequence Diagram](./docs/mcp-oauth-sequence.mermaid)
 - [DCR Sequence Diagram](./docs/mcp-oauth-sequence-dcr.mermaid)
+- [CIMD Sequence Diagram](./docs/mcp-oauth-sequence-cimd.mermaid)
 
 ## Dynamic Client Registration (DCR)
 
@@ -105,13 +118,63 @@ This approach allows us to maintain compliance with the MCP specification's DCR 
 
 See our [DCR Security Recommendations](./docs/dcr-security-recommendations.md) to enhance the security of the registration process.
 
+## Client ID Metadata Documents (CIMD)
+
+The MCP Authorization Specification (2025-11-25) introduced Client ID Metadata Documents as the recommended client registration method. CIMD allows a client to use an HTTPS URL as its `client_id`, with the URL hosting a JSON document describing the client's OAuth metadata.
+
+### How CIMD Works
+
+1. Client publishes a metadata document at a URL (e.g., `http://localhost:3003/client-metadata.json`)
+2. During OAuth authorization, the client uses this URL as its `client_id`
+3. The authorization server fetches the metadata document from the URL
+4. The server validates the document structure and redirect URIs
+5. The client proceeds with a standard OAuth 2.1 flow
+
+### CIMD Metadata Document Example
+
+```json
+{
+  "client_id": "http://localhost:3003/client-metadata.json",
+  "redirect_uris": ["http://localhost:3003/callback"],
+  "client_name": "MCP CIMD Demo Client",
+  "grant_types": ["authorization_code"],
+  "response_types": ["code"],
+  "token_endpoint_auth_method": "none"
+}
+```
+
+### CIMD Authorization Proxy
+
+AWS Cognito does not natively support Client ID Metadata Documents, just as it doesn't natively support DCR. This implementation bridges CIMD transparently through the MCP server's authorization proxy:
+
+- The MCP server advertises `client_id_metadata_document_supported: true` in authorization server metadata
+- The MCP server overrides `authorization_endpoint` and `token_endpoint` in metadata to point to itself
+- When a client presents a URL-based `client_id`:
+  1. The proxy fetches and validates the client's metadata document
+  2. Transparently creates a Cognito app client via the existing DCR infrastructure
+  3. Forwards the request to Cognito with the mapped credentials
+- When a client presents a standard `client_id` (pre-registered or DCR): requests are passed through to Cognito unchanged
+
+The metadata-client has **zero custom code** for CIMD — it simply uses its metadata URL as `client_id` with standard OAuth endpoints, just like any spec-compliant client. All bridging is handled server-side.
+
+### CIMD Security
+
+The authorization proxy includes:
+- SSRF protection (blocks private IP ranges, enforces HTTPS in production)
+- Strict `client_id` validation (must match the metadata URL exactly)
+- Redirect URI validation
+- Response size limits (64KB) and fetch timeouts (5s)
+- In-memory caching to prevent redundant fetches
+
+**Note**: In development, `http://localhost` URLs are permitted. Production deployments must use HTTPS.
+
 ## Quick Start
 
 ### Prerequisites
-- Node.js installed
+- Node.js 18+ installed
 - AWS test account with access to:
     - Cognito for Authorization Server (1 user pool, 2 app clients)
-    - API Gateway / Lambda / DynamoDB for DCR (2 resources, 2 functions, 1 table) 
+    - API Gateway / Lambda / DynamoDB for DCR and CIMD bridge (2 resources, 2 functions, 1 table)
     - CloudFormation for deploy (1 stack)
 - Basic knowledge of OAuth 2.1 flows
 
@@ -135,16 +198,17 @@ See our [DCR Security Recommendations](./docs/dcr-security-recommendations.md) t
 4. Review generated `.env` files in:
    - `src/client/.env`
    - `src/auto-client/.env`
+   - `src/metadata-client/.env`
    - `src/mcp-server/.env`
    - Compare with `.env.example` files
    - Manually verify/update CLIENT_SECRET if needed
 
 ### Running the Application
-1. Start both clients and server
+1. Start all services (server + 3 clients)
    ```bash
    npm run dev
    ```
-2. Visit http://localhost:3000 to test the OAuth flow
+2. Visit http://localhost:3000 to test the **pre-registered client** OAuth flow
 
 3. Sign Up for a New User
    - Click the "Log in" button
@@ -155,7 +219,9 @@ See our [DCR Security Recommendations](./docs/dcr-security-recommendations.md) t
 
 4. Click the "Fetch MCP Data" button to make an authenticated request to the MCP server
 
-5. Visit http://localhost:3002 to test the DCR flow, auto-discovery client with Dynamic Client Registration.
+5. Visit http://localhost:3002 to test the **DCR flow** (auto-discovery client with Dynamic Client Registration)
+
+6. Visit http://localhost:3003 to test the **CIMD flow** (Client ID Metadata Document client)
 
 ### Cleanup
 1. Cleanup AWS resources
@@ -177,10 +243,11 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 ## References
 
-- [Model Context Protocol Official Specification](https://modelcontextprotocol.io/specification/draft/basic/authorization)
-- [OAuth 2.1 Draft](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-12)
-- [OAuth 2.0 Protected Resource Metadata](https://datatracker.ietf.org/doc/rfc9728/)
-- [OAuth 2.0 Dynamic Client Registration Protocol](https://datatracker.ietf.org/doc/rfc7591/)
+- [Model Context Protocol Authorization Specification (2025-11-25)](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)
+- [OAuth 2.1 Draft](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13)
+- [OAuth 2.0 Protected Resource Metadata (RFC 9728)](https://datatracker.ietf.org/doc/rfc9728/)
+- [OAuth 2.0 Dynamic Client Registration Protocol (RFC 7591)](https://datatracker.ietf.org/doc/rfc7591/)
+- [OAuth Client ID Metadata Document (Draft)](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document)
 - [AWS Cognito Developer Guide](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools.html)
 
 ## License

--- a/docs/architecture-guide.md
+++ b/docs/architecture-guide.md
@@ -52,7 +52,17 @@ A variant of the MCP Client that adds:
 - OAuth flow using dynamically obtained credentials
 - **Fully provider-agnostic** - works with any OAuth server that supports DCR
 
-### 5. Dynamic Client Registration API (API Gateway + Lambda)
+### 5. Metadata Client - CIMD (Express.js)
+
+A standard OAuth client that uses Client ID Metadata Documents for identity:
+- **Hosts its own metadata document** at `/client-metadata.json`
+- Uses the metadata URL as its `client_id` (e.g., `http://localhost:3003/client-metadata.json`)
+- Checks for `client_id_metadata_document_supported` in authorization server metadata
+- Uses standard `authorization_endpoint` and `token_endpoint` with URL as `client_id`
+- **No custom code** — the MCP server's authorization proxy handles CIMD transparently
+- Demonstrates the MCP 2025-11-25 recommended client registration method
+
+### 6. Dynamic Client Registration API (API Gateway + Lambda)
 
 Provides the backend for Dynamic Client Registration:
 - API Gateway endpoints for registering clients
@@ -104,6 +114,40 @@ The complete OAuth 2.1 flow in this implementation works as follows:
    - When access token expires, client uses refresh token
    - Client requests new access token from Cognito
    - Client updates stored tokens
+
+## Client ID Metadata Document (CIMD) Flow
+
+The CIMD flow provides a stateless, URL-based client identity mechanism:
+
+1. **Metadata Publishing**
+   - Client hosts a JSON metadata document at a URL (e.g., `http://localhost:3003/client-metadata.json`)
+   - Document contains: `client_id` (matching the URL), `redirect_uris`, `client_name`, etc.
+
+2. **Discovery with CIMD Check**
+   - Client discovers the authorization server via the standard PRM flow
+   - Client checks for `client_id_metadata_document_supported: true` in auth server metadata
+
+3. **Standard OAuth Flow with URL client_id**
+   - Client redirects to the discovered `authorization_endpoint` using its metadata URL as `client_id`
+   - The MCP server's authorization proxy detects the URL-based `client_id`
+   - Proxy fetches and validates the metadata document from the client's URL
+   - Proxy creates a Cognito app client via existing DCR Lambda infrastructure (cached)
+   - Proxy forwards the request to Cognito with mapped credentials
+   - User authenticates, Cognito redirects back to client with authorization code
+
+4. **Token Exchange**
+   - Client POSTs to the discovered `token_endpoint` using its metadata URL as `client_id`
+   - Proxy maps the URL to cached Cognito credentials and forwards to Cognito
+   - Client receives tokens — flow is identical to pre-registered and DCR clients from here
+
+### CIMD vs DCR
+
+| Aspect | DCR | CIMD |
+|--------|-----|------|
+| Client Identity | Server-assigned UUID | Client-published URL |
+| Registration | Client POSTs to registration endpoint | Server fetches client's metadata |
+| Metadata Updates | Requires re-registration | Updated at the URL (cached) |
+| Trust Model | Server trusts registration request | Server validates published metadata |
 
 ## Dynamic Client Registration Flow
 
@@ -196,7 +240,14 @@ This implementation follows OAuth 2.1 and MCP security best practices:
      * Initial access tokens for registration authorization
      * Client authentication (mTLS) for secure registration
      * Registration policies and approval workflows
-     * Rate limiting to prevent abuse   
+     * Rate limiting to prevent abuse
+
+7. **Client ID Metadata Document Security**
+   - SSRF protection when fetching metadata (blocked private IP ranges)
+   - HTTPS enforcement in production (HTTP localhost allowed in dev only)
+   - Strict `client_id` to URL matching prevents impersonation
+   - Response size limits (64KB) and fetch timeouts (5s) prevent abuse
+   - Redirect URI validation prevents open-redirect attacks
 
 ## Diagrams
 - [Architecture Diagram](./mcp-oauth-architecture.mermaid)

--- a/docs/mcp-oauth-sequence-cimd.mermaid
+++ b/docs/mcp-oauth-sequence-cimd.mermaid
@@ -1,0 +1,52 @@
+sequenceDiagram
+    participant User
+    participant MetadataClient as Metadata Client<br/>(localhost:3003)
+    participant MCPServer as MCP Server<br/>(localhost:3001)
+    participant DCRLambda as DCR Lambda<br/>(API Gateway)
+    participant Cognito as AWS Cognito<br/>(Auth Server)
+
+    Note over MetadataClient: Client hosts metadata at<br/>/client-metadata.json
+
+    User->>MetadataClient: Click "Log in"
+
+    Note over MetadataClient,MCPServer: Step 1: Discovery (same as all clients)
+    MetadataClient->>MCPServer: GET /v1/contexts (no auth)
+    MCPServer-->>MetadataClient: 401 + WWW-Authenticate header<br/>(resource_metadata, scope)
+    MetadataClient->>MCPServer: GET /.well-known/oauth-protected-resource
+    MCPServer-->>MetadataClient: Protected Resource Metadata (PRM)
+    MetadataClient->>MCPServer: GET /.well-known/oauth-authorization-server
+    MCPServer-->>MetadataClient: Auth Server Metadata<br/>(authorization_endpoint, token_endpoint point to MCP server,<br/>client_id_metadata_document_supported: true)
+
+    Note over MetadataClient: Step 2: Check CIMD support
+    MetadataClient->>MetadataClient: Verify client_id_metadata_document_supported === true
+
+    Note over MetadataClient,Cognito: Step 3: Standard OAuth Authorization (client uses URL as client_id)
+    MetadataClient->>MCPServer: GET /oauth/authorize<br/>client_id=http://localhost:3003/client-metadata.json<br/>code_challenge=xxx, state=xxx, resource=http://localhost:3001
+    Note over MCPServer: Detects URL-based client_id
+    MCPServer->>MetadataClient: Fetch GET /client-metadata.json
+    MetadataClient-->>MCPServer: Client ID Metadata Document (JSON)
+    MCPServer->>MCPServer: Validate: client_id matches URL,<br/>redirect_uris present, structure valid
+
+    Note over MCPServer,DCRLambda: Bridge to DCR (transparent to client)
+    MCPServer->>DCRLambda: POST /v1/register<br/>(redirect_uris, client_name, scope)
+    DCRLambda->>Cognito: CreateUserPoolClient
+    Cognito-->>DCRLambda: cognito_client_id, client_secret
+    DCRLambda-->>MCPServer: Registration response (cached)
+
+    MCPServer->>Cognito: Redirect to /oauth2/authorize<br/>(with mapped cognito_client_id)
+    Cognito->>User: Display login / consent
+    User->>Cognito: Authenticate
+    Cognito-->>MetadataClient: Redirect with authorization code
+
+    Note over MetadataClient,Cognito: Step 4: Token Exchange (client still uses URL as client_id)
+    MetadataClient->>MCPServer: POST /oauth/token<br/>client_id=http://localhost:3003/client-metadata.json<br/>code=xxx, code_verifier=xxx
+    Note over MCPServer: Maps URL client_id to cached<br/>Cognito credentials
+    MCPServer->>Cognito: POST /oauth2/token<br/>(with mapped cognito_client_id + client_secret)
+    Cognito-->>MCPServer: access_token, refresh_token, id_token
+    MCPServer-->>MetadataClient: access_token, refresh_token, id_token
+
+    Note over MetadataClient,MCPServer: Step 5: Authenticated API Call
+    MetadataClient->>MCPServer: GET /v1/contexts<br/>Authorization: Bearer {access_token}
+    MCPServer->>MCPServer: Validate JWT (JWKS, issuer)
+    MCPServer-->>MetadataClient: Protected resource data
+    MetadataClient-->>User: Display MCP data

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -42,6 +42,7 @@ This guide walks through setting up and running the MCP OAuth 2.1 demo with AWS 
    - Review generated `.env` files in:
      * `src/client/.env`
      * `src/auto-client/.env`
+     * `src/metadata-client/.env`
      * `src/mcp-server/.env`
    - Compare with `.env.example` files
    - Manually verify/update CLIENT_SECRET if needed
@@ -71,17 +72,25 @@ npm run dev
 
 ```
 /mcp-server
-  - Minimal protected resource server
+  - Express.js Resource Server with OAuth endpoints
   - Serves /.well-known/oauth-protected-resource
+  - Proxies authorization server metadata from Cognito
+  - CIMD resolution bridge endpoint
+
+/client
+  - Pre-registered client (static credentials)
+  - Handles discovery, PKCE, and token usage
 
 /auto-client
-  - Dynamic client registration example
+  - Dynamic client registration (DCR) example
   - Auto-discovers and registers with authorization server
   - Handles OAuth 2.1 flow with dynamically obtained credentials
 
-/client
-  - Example client to demonstrate the OAuth 2.1 flow
-  - Handles discovery, PKCE, and token usage
+/metadata-client
+  - Client ID Metadata Document (CIMD) example
+  - Publishes metadata at /client-metadata.json
+  - Uses metadata URL as client_id with standard OAuth endpoints
+  - No custom code — proxy handles CIMD transparently
 
 /docs
   - Setup guides and explanations
@@ -115,6 +124,20 @@ Visit `http://localhost:3002` in your browser and follow these steps:
 3. After authentication, you'll be redirected back to the auto-client
 4. Click "Fetch MCP Data" to make an authenticated request with the dynamically registered client
 
+### 6. CIMD Client (Client ID Metadata Document)
+
+Visit `http://localhost:3003` in your browser and follow these steps:
+
+1. Verify the metadata document is served at `http://localhost:3003/client-metadata.json`
+2. Click the "Log in" button
+3. The client will:
+   - Auto-discover the MCP server and authorization endpoints
+   - Check for `client_id_metadata_document_supported` in auth server metadata
+   - Redirect to the authorization endpoint using its metadata URL as `client_id`
+   - The MCP server's proxy transparently resolves the CIMD and forwards to Cognito
+   - Cognito presents the login page
+4. After authentication, you'll be redirected back to the metadata client
+5. Click "Fetch MCP Data" to make an authenticated request
 
 ## Architecture Overview
 - Detailed [Architecture Overview](./architecture-guide.md)
@@ -126,9 +149,11 @@ Visit `http://localhost:3002` in your browser and follow these steps:
    - Implements OAuth 2.1 authorization code flow with PKCE
    - Makes authenticated requests to the MCP server
 
-2. **MCP Server**: Implemented as AWS API Gateway + Lambda that:
+2. **MCP Server**: Implemented as Express.js Resource Server that:
    - Serves the Protected Resource Metadata document
-   - Validates access tokens from Cognito
+   - Proxies authorization server metadata (augments with DCR and CIMD support)
+   - Proxies authorization and token endpoints for transparent CIMD handling
+   - Validates access tokens using dynamically discovered JWKS
    - Provides protected API endpoints for MCP operations
 
 3. **AWS Cognito**: Acts as the OAuth 2.1 Authorization Server:
@@ -157,10 +182,11 @@ mcp-oauth2-aws-cognito/
 │   └── cloudformation/        # CloudFormation templates
 ├── scripts/                   # Deployment scripts
 ├── src/
-│   ├── mcp-server/            # MCP server implementation
-│   ├── auto-client/           # MCP auto discovery client implementation
-│   ├── client/                # MCP client implementation
-│   └── shared/                # Shared utilities
+│   ├── mcp-server/            # MCP Resource Server (Express.js)
+│   ├── client/                # Pre-registered client (static credentials)
+│   ├── auto-client/           # DCR auto-discovery client
+│   ├── metadata-client/       # CIMD client (Client ID Metadata Document)
+│   └── shared/                # Shared configuration
 └── docs/                      # Documentation
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,19 +1,21 @@
 {
     "name": "mcp-oauth2-aws-cognito",
     "version": "1.0.0",
-    "description": "Demo of MCP OAuth2.1 integration with AWS Cognito",
+    "description": "Demo of MCP OAuth 2.1 integration with AWS Cognito — showcasing pre-registered, DCR, and CIMD client registration methods",
     "main": "index.js",
     "scripts": {
         "install:client": "cd src/client && npm install",
         "install:auto-client": "cd src/auto-client && npm install",
         "install:server": "cd src/mcp-server && npm install",
-        "install:all": "npm install && npm run install:client && npm run install:auto-client && npm run install:server",
+        "install:metadata-client": "cd src/metadata-client && npm install",
+        "install:all": "npm install && npm run install:client && npm run install:auto-client && npm run install:metadata-client && npm run install:server",
         "deploy": "node scripts/deploy.js",
         "cleanup": "node scripts/cleanup.js",
         "start:server": "cd src/mcp-server && node index.js",
         "start:client": "cd src/client && node index.js",
         "start:auto-client": "cd src/auto-client && node index.js",
-        "dev": "concurrently \"npm run start:server\" \"npm run start:client\" \"npm run start:auto-client\""
+        "start:metadata-client": "cd src/metadata-client && node index.js",
+        "dev": "concurrently \"npm run start:server\" \"npm run start:client\" \"npm run start:auto-client\" \"npm run start:metadata-client\""
     },
     "repository": {
         "type": "git",
@@ -22,9 +24,14 @@
     "keywords": [
         "mcp",
         "oauth",
+        "oauth2.1",
         "aws",
         "cognito",
-        "dynamic-client-registration"
+        "dynamic-client-registration",
+        "client-id-metadata-document",
+        "cimd",
+        "pkce",
+        "model-context-protocol"
     ],
     "author": "Empires Security Labs",
     "license": "MIT",

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -200,6 +200,19 @@ MCP_SERVER_URL=http://localhost:3001
 DCR_ENDPOINT=${dcrEndpoint}
 `;
 
+  // Create metadata-client .env file (CIMD client)
+  const metadataClientEnv = `# Metadata Client Configuration (CIMD)
+METADATA_CLIENT_PORT=3003
+METADATA_CLIENT_URL=http://localhost:3003
+
+# MCP Server URL
+MCP_SERVER_URL=http://localhost:3001
+
+# Cognito Configuration (shared config uses these for auth server URL construction)
+COGNITO_REGION=${REGION}
+COGNITO_USER_POOL_ID=${userPoolId}
+`;
+
   // Create server .env file
   const serverEnv = `# Server Configuration
 PORT=3001
@@ -219,6 +232,7 @@ DCR_ENDPOINT=${dcrEndpoint}
   // Ensure directories exist
   ensureDirectoryExists(path.join(basePath, "src", "client"));
   ensureDirectoryExists(path.join(basePath, "src", "auto-client"));
+  ensureDirectoryExists(path.join(basePath, "src", "metadata-client"));
   ensureDirectoryExists(path.join(basePath, "src", "mcp-server"));
 
   // Write the .env files
@@ -227,9 +241,13 @@ DCR_ENDPOINT=${dcrEndpoint}
     path.join(basePath, "src", "auto-client", ".env"),
     autoClientEnv
   );
+  fs.writeFileSync(
+    path.join(basePath, "src", "metadata-client", ".env"),
+    metadataClientEnv
+  );
   fs.writeFileSync(path.join(basePath, "src", "mcp-server", ".env"), serverEnv);
 
-  console.log("Created .env files for client, auto-client, and server");
+  console.log("Created .env files for client, auto-client, metadata-client, and server");
 }
 
 function ensureDirectoryExists(directory) {

--- a/src/mcp-server/.env.example
+++ b/src/mcp-server/.env.example
@@ -7,6 +7,7 @@ COGNITO_REGION=us-east-1
 COGNITO_USER_POOL_ID=your-user-pool-id
 COGNITO_CLIENT_ID=your-client-id
 COGNITO_CLIENT_SECRET=your-client-secret
+COGNITO_DOMAIN=your-domain
 
 # Dynamic Client Registration Endpoint
 DCR_ENDPOINT=https://your-api-gateway-url.execute-api.region.amazonaws.com/v1/register

--- a/src/mcp-server/cimd-validator.js
+++ b/src/mcp-server/cimd-validator.js
@@ -1,0 +1,259 @@
+const axios = require('axios');
+const { URL } = require('url');
+const dns = require('dns');
+const { promisify } = require('util');
+
+const dnsResolve = promisify(dns.resolve4);
+
+// In-memory cache for validated metadata documents (5 min TTL)
+const metadataCache = new Map();
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const MAX_RESPONSE_SIZE = 65536; // 64KB
+const FETCH_TIMEOUT_MS = 5000;
+
+// Private/reserved IP ranges to block (SSRF protection)
+const BLOCKED_IP_RANGES = [
+  /^127\./, // Loopback
+  /^10\./, // Class A private
+  /^172\.(1[6-9]|2[0-9]|3[01])\./, // Class B private
+  /^192\.168\./, // Class C private
+  /^169\.254\./, // Link-local
+  /^0\./, // Current network
+  /^::1$/, // IPv6 loopback
+  /^fc00:/, // IPv6 unique local
+  /^fe80:/, // IPv6 link-local
+];
+
+function isBlockedIp(ip) {
+  return BLOCKED_IP_RANGES.some(pattern => pattern.test(ip));
+}
+
+/**
+ * Validate a metadata URL for safety and correctness
+ * @param {string} urlString - The metadata URL to validate
+ * @returns {URL} The parsed URL object
+ * @throws {Error} If the URL is invalid or blocked
+ */
+async function validateMetadataUrl(urlString) {
+  if (!urlString || typeof urlString !== 'string') {
+    throw new Error('Metadata URL is required');
+  }
+
+  if (urlString.length > 2048) {
+    throw new Error('Metadata URL exceeds maximum length of 2048 characters');
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(urlString);
+  } catch {
+    throw new Error('Invalid metadata URL format');
+  }
+
+  // Must have a path component (not just the domain)
+  if (!parsed.pathname || parsed.pathname === '/') {
+    throw new Error('Metadata URL must contain a path component');
+  }
+
+  // No fragments allowed
+  if (parsed.hash) {
+    throw new Error('Metadata URL must not contain fragments');
+  }
+
+  // No credentials in URL
+  if (parsed.username || parsed.password) {
+    throw new Error('Metadata URL must not contain credentials');
+  }
+
+  // No dot segments in path
+  if (/\/(\.\.?)(\/|$)/.test(parsed.pathname)) {
+    throw new Error('Metadata URL must not contain dot path segments');
+  }
+
+  const isDev = process.env.NODE_ENV !== 'production';
+  const isLocalhost = parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1';
+
+  // Enforce HTTPS in production, allow HTTP for localhost in dev
+  if (parsed.protocol === 'http:') {
+    if (!isDev || !isLocalhost) {
+      throw new Error('Metadata URL must use HTTPS scheme (HTTP only allowed for localhost in development)');
+    }
+  } else if (parsed.protocol !== 'https:') {
+    throw new Error('Metadata URL must use HTTPS scheme');
+  }
+
+  // SSRF protection: resolve hostname and check IP (skip for localhost in dev)
+  if (!isLocalhost) {
+    try {
+      const addresses = await dnsResolve(parsed.hostname);
+      for (const ip of addresses) {
+        if (isBlockedIp(ip)) {
+          throw new Error('Metadata URL resolves to a blocked IP address');
+        }
+      }
+    } catch (err) {
+      if (err.message.includes('blocked IP')) throw err;
+      throw new Error(`Cannot resolve metadata URL hostname: ${parsed.hostname}`);
+    }
+  }
+
+  return parsed;
+}
+
+/**
+ * Fetch and validate a Client ID Metadata Document
+ * @param {string} metadataUrl - The URL to fetch the metadata from
+ * @returns {Promise<Object>} The validated metadata document
+ */
+async function fetchAndValidateMetadata(metadataUrl) {
+  // Check cache first
+  const cached = metadataCache.get(metadataUrl);
+  if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
+    console.log(`CIMD cache hit for: ${metadataUrl}`);
+    return cached.metadata;
+  }
+
+  // Validate URL
+  await validateMetadataUrl(metadataUrl);
+
+  // Fetch the metadata document
+  let response;
+  try {
+    response = await axios.get(metadataUrl, {
+      timeout: FETCH_TIMEOUT_MS,
+      maxContentLength: MAX_RESPONSE_SIZE,
+      maxRedirects: 2,
+      headers: {
+        'Accept': 'application/json',
+        'User-Agent': 'MCP-Server-CIMD-Validator/1.0'
+      },
+      validateStatus: (status) => status === 200
+    });
+  } catch (err) {
+    if (err.code === 'ECONNABORTED') {
+      throw new Error('Metadata document fetch timed out');
+    }
+    throw new Error(`Failed to fetch metadata document: ${err.message}`);
+  }
+
+  const metadata = response.data;
+
+  if (!metadata || typeof metadata !== 'object') {
+    throw new Error('Metadata document is not a valid JSON object');
+  }
+
+  // Validate required field: client_id must match the URL exactly
+  if (!metadata.client_id) {
+    throw new Error('Metadata document missing required field: client_id');
+  }
+  if (metadata.client_id !== metadataUrl) {
+    throw new Error(`Metadata client_id "${metadata.client_id}" does not match the document URL "${metadataUrl}"`);
+  }
+
+  // Validate required field: client_name (spec MUST include client_id, client_name, redirect_uris)
+  if (!metadata.client_name || typeof metadata.client_name !== 'string' || metadata.client_name.trim() === '') {
+    throw new Error('Metadata document missing or empty required field: client_name');
+  }
+
+  // Validate required field: redirect_uris
+  if (!metadata.redirect_uris || !Array.isArray(metadata.redirect_uris) || metadata.redirect_uris.length === 0) {
+    throw new Error('Metadata document missing or empty required field: redirect_uris');
+  }
+
+  // Validate each redirect_uri is a valid URL
+  for (const uri of metadata.redirect_uris) {
+    try {
+      new URL(uri);
+    } catch {
+      throw new Error(`Invalid redirect_uri in metadata: ${uri}`);
+    }
+  }
+
+  // Apply defaults for optional fields
+  if (!metadata.grant_types) {
+    metadata.grant_types = ['authorization_code'];
+  }
+  if (!metadata.response_types) {
+    metadata.response_types = ['code'];
+  }
+  if (!metadata.token_endpoint_auth_method) {
+    metadata.token_endpoint_auth_method = 'none';
+  }
+
+  // Cache the validated metadata
+  metadataCache.set(metadataUrl, {
+    metadata,
+    timestamp: Date.now()
+  });
+
+  console.log(`CIMD validated and cached for: ${metadataUrl}`);
+  return metadata;
+}
+
+// Cache for CIMD client_id URL -> Cognito credentials mapping
+const clientMappingCache = new Map();
+
+/**
+ * Check if a client_id is a URL (CIMD) vs a plain string (pre-registered/DCR)
+ */
+function isUrlClientId(clientId) {
+  if (!clientId) return false;
+  try {
+    const parsed = new URL(clientId);
+    return parsed.protocol === 'https:' || parsed.protocol === 'http:';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve a URL-based client_id to Cognito credentials via CIMD + DCR bridge.
+ * Returns cached mapping if available.
+ */
+async function resolveClientId(clientIdUrl, dcrEndpoint) {
+  // Check mapping cache
+  const cached = clientMappingCache.get(clientIdUrl);
+  if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
+    console.log(`CIMD mapping cache hit: ${clientIdUrl} -> ${cached.mapping.client_id}`);
+    return cached.mapping;
+  }
+
+  // Fetch and validate the metadata document
+  const metadata = await fetchAndValidateMetadata(clientIdUrl);
+
+  console.log(`CIMD validated for client: ${metadata.client_name || metadata.client_id}`);
+
+  // Bridge to DCR: register a Cognito client
+  const dcrRequest = {
+    redirect_uris: metadata.redirect_uris,
+    client_name: metadata.client_name || new URL(clientIdUrl).hostname,
+    scope: 'openid profile email'
+  };
+
+  const dcrResponse = await axios.post(dcrEndpoint, dcrRequest, {
+    headers: { 'Content-Type': 'application/json' }
+  });
+
+  const mapping = {
+    client_id: dcrResponse.data.client_id,
+    client_secret: dcrResponse.data.client_secret,
+    redirect_uris: metadata.redirect_uris,
+    scope: dcrResponse.data.scope || metadata.scope
+  };
+
+  // Cache the mapping
+  clientMappingCache.set(clientIdUrl, {
+    mapping,
+    timestamp: Date.now()
+  });
+
+  console.log(`CIMD resolved: ${clientIdUrl} -> Cognito client ${mapping.client_id}`);
+  return mapping;
+}
+
+module.exports = {
+  validateMetadataUrl,
+  fetchAndValidateMetadata,
+  isUrlClientId,
+  resolveClientId
+};

--- a/src/mcp-server/index.js
+++ b/src/mcp-server/index.js
@@ -2,6 +2,7 @@ const express = require('express');
 const cors = require('cors');
 const { createResourceMetadata } = require('./resource-metadata');
 const { validateToken } = require('./token-validator');
+const { isUrlClientId, resolveClientId } = require('./cimd-validator');
 const config = require('../shared/config');
 
 const app = express();
@@ -57,7 +58,22 @@ app.get('/.well-known/oauth-authorization-server', async (req, res) => {
     if (!metadata.code_challenge_methods_supported) {
       metadata.code_challenge_methods_supported = ['S256'];
     }
-    
+
+    // Advertise Client ID Metadata Document support (CIMD)
+    // Cognito doesn't natively support CIMD, but the MCP server bridges it
+    metadata.client_id_metadata_document_supported = true;
+
+    // Store the original Cognito endpoints for proxying
+    app.locals.cognitoAuthorizationEndpoint = metadata.authorization_endpoint;
+    app.locals.cognitoTokenEndpoint = metadata.token_endpoint;
+
+    // Override authorization and token endpoints to point to MCP server proxy
+    // This allows transparent CIMD handling — clients use standard endpoints,
+    // and the proxy bridges URL-based client_ids to Cognito via DCR
+    const serverBaseUrl = config.mcpServer.baseUrl;
+    metadata.authorization_endpoint = `${serverBaseUrl}/oauth/authorize`;
+    metadata.token_endpoint = `${serverBaseUrl}/oauth/token`;
+
     res.json(metadata);
   } catch (error) {
     console.error('Error proxying authorization server metadata:', error.message);
@@ -69,13 +85,144 @@ app.get('/.well-known/oauth-authorization-server', async (req, res) => {
 });
 
 
+// OAuth Authorization Proxy
+// Transparently handles URL-based client_ids (CIMD) by resolving them to
+// Cognito credentials, then redirects to Cognito's authorization endpoint.
+// Non-URL client_ids are passed through unchanged.
+app.get('/oauth/authorize', async (req, res) => {
+  try {
+    const clientId = req.query.client_id;
+    const cognitoAuthEndpoint = app.locals.cognitoAuthorizationEndpoint;
+
+    if (!cognitoAuthEndpoint) {
+      return res.status(503).json({
+        error: 'server_error',
+        error_description: 'Authorization server metadata not yet loaded. Try requesting /.well-known/oauth-authorization-server first.'
+      });
+    }
+
+    // Build the redirect URL starting from Cognito's authorization endpoint
+    const authUrl = new URL(cognitoAuthEndpoint);
+
+    // Copy all query parameters
+    for (const [key, value] of Object.entries(req.query)) {
+      if (key !== 'client_id') {
+        authUrl.searchParams.set(key, value);
+      }
+    }
+
+    if (isUrlClientId(clientId)) {
+      // CIMD flow: resolve URL client_id to Cognito credentials
+      console.log(`CIMD authorize: resolving URL client_id: ${clientId}`);
+
+      const dcrEndpoint = process.env.DCR_ENDPOINT;
+      if (!dcrEndpoint) {
+        return res.status(500).json({
+          error: 'server_error',
+          error_description: 'DCR endpoint not configured'
+        });
+      }
+
+      const mapping = await resolveClientId(clientId, dcrEndpoint);
+
+      // Use the mapped Cognito client_id
+      authUrl.searchParams.set('client_id', mapping.client_id);
+
+      // Validate that the requested redirect_uri is in the metadata's allowed list
+      const requestedRedirectUri = req.query.redirect_uri;
+      if (requestedRedirectUri && !mapping.redirect_uris.includes(requestedRedirectUri)) {
+        return res.status(400).json({
+          error: 'invalid_request',
+          error_description: 'redirect_uri not registered in client metadata document'
+        });
+      }
+    } else {
+      // Non-CIMD: pass through client_id unchanged
+      authUrl.searchParams.set('client_id', clientId);
+    }
+
+    console.log(`Proxying authorize to: ${authUrl.origin}${authUrl.pathname}`);
+    res.redirect(authUrl.toString());
+  } catch (error) {
+    console.error('Authorization proxy error:', error.message);
+    res.status(400).json({
+      error: 'invalid_client_metadata',
+      error_description: error.message
+    });
+  }
+});
+
+// OAuth Token Proxy
+// Transparently handles URL-based client_ids (CIMD) by mapping them to
+// Cognito credentials, then forwards the token request to Cognito.
+// Non-URL client_ids are passed through unchanged.
+app.use('/oauth/token', express.urlencoded({ extended: true }));
+app.post('/oauth/token', async (req, res) => {
+  try {
+    const clientId = req.body.client_id;
+    const cognitoTokenEndpoint = app.locals.cognitoTokenEndpoint;
+
+    if (!cognitoTokenEndpoint) {
+      return res.status(503).json({
+        error: 'server_error',
+        error_description: 'Authorization server metadata not yet loaded. Try requesting /.well-known/oauth-authorization-server first.'
+      });
+    }
+
+    // Build the token request body
+    const tokenParams = { ...req.body };
+
+    if (isUrlClientId(clientId)) {
+      // CIMD flow: look up the mapped Cognito credentials
+      console.log(`CIMD token: mapping URL client_id: ${clientId}`);
+
+      const dcrEndpoint = process.env.DCR_ENDPOINT;
+      const mapping = await resolveClientId(clientId, dcrEndpoint);
+
+      // Validate redirect_uri against CIMD metadata (defense-in-depth)
+      if (tokenParams.redirect_uri && !mapping.redirect_uris.includes(tokenParams.redirect_uri)) {
+        return res.status(400).json({
+          error: 'invalid_request',
+          error_description: 'redirect_uri not registered in client metadata document'
+        });
+      }
+
+      // Replace with Cognito credentials
+      tokenParams.client_id = mapping.client_id;
+      tokenParams.client_secret = mapping.client_secret;
+    }
+
+    // Forward to Cognito's token endpoint
+    const axios = require('axios');
+    const querystring = require('querystring');
+
+    const tokenResponse = await axios.post(
+      cognitoTokenEndpoint,
+      querystring.stringify(tokenParams),
+      { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }
+    );
+
+    res.json(tokenResponse.data);
+  } catch (error) {
+    console.error('Token proxy error:', error.message);
+    if (error.response) {
+      // Forward Cognito's error response
+      return res.status(error.response.status).json(error.response.data);
+    }
+    res.status(400).json({
+      error: 'invalid_request',
+      error_description: error.message
+    });
+  }
+});
+
 // Middleware to validate access tokens
 const requireAuth = async (req, res, next) => {
   const authHeader = req.headers.authorization;
   
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
     return res.status(401).set({
-      'WWW-Authenticate': `Bearer resource_metadata="${config.mcpServer.baseUrl}/.well-known/oauth-protected-resource"`
+      'WWW-Authenticate': `Bearer resource_metadata="${config.mcpServer.baseUrl}/.well-known/oauth-protected-resource", scope="openid profile email mcp-api/read"`
     }).json({
       error: 'unauthorized',
       error_description: 'Valid bearer token required'
@@ -91,7 +238,7 @@ const requireAuth = async (req, res, next) => {
   } catch (error) {
     console.error('Token validation failed:', error.message);
     return res.status(401).set({
-      'WWW-Authenticate': `Bearer resource_metadata="${config.mcpServer.baseUrl}/.well-known/oauth-protected-resource", error="invalid_token", error_description="${error.message}"`
+      'WWW-Authenticate': `Bearer resource_metadata="${config.mcpServer.baseUrl}/.well-known/oauth-protected-resource", scope="openid profile email mcp-api/read", error="invalid_token", error_description="${error.message}"`
     }).json({
       error: 'unauthorized',
       error_description: error.message

--- a/src/metadata-client/.env.example
+++ b/src/metadata-client/.env.example
@@ -1,0 +1,10 @@
+# Metadata Client Configuration
+METADATA_CLIENT_PORT=3003
+METADATA_CLIENT_URL=http://localhost:3003
+
+# MCP Server URL
+MCP_SERVER_URL=http://localhost:3001
+
+# Cognito Configuration (shared config uses these for auth server URL construction)
+COGNITO_REGION=your-region
+COGNITO_USER_POOL_ID=your-user-pool-id

--- a/src/metadata-client/auth-flow.js
+++ b/src/metadata-client/auth-flow.js
@@ -1,0 +1,119 @@
+const axios = require('axios');
+const crypto = require('crypto');
+const querystring = require('querystring');
+
+// Generate a code verifier and challenge for PKCE
+function generatePkce() {
+  const codeVerifier = crypto.randomBytes(32).toString('base64url');
+  const codeChallenge = crypto
+    .createHash('sha256')
+    .update(codeVerifier)
+    .digest('base64url');
+
+  return { codeVerifier, codeChallenge };
+}
+
+// Initiate the OAuth authorization flow using metadata URL as client_id
+// Returns { authUrl, codeVerifier, state } — caller stores in session
+async function initiateAuthFlow(authServerInfo, metadataUrl) {
+  const { authServerMetadata } = authServerInfo;
+
+  if (!authServerMetadata.authorization_endpoint) {
+    throw new Error('Authorization endpoint not found in server metadata');
+  }
+
+  // Generate PKCE values
+  const { codeVerifier, codeChallenge } = generatePkce();
+
+  // Generate a random state value for CSRF protection
+  const state = crypto.randomBytes(16).toString('hex');
+
+  // Build the authorization URL using standard discovered endpoint
+  const authUrl = new URL(authServerMetadata.authorization_endpoint);
+
+  // Use the metadata URL as the client_id — this is the CIMD standard
+  const config = require('../shared/config');
+  authUrl.searchParams.append('client_id', metadataUrl);
+  authUrl.searchParams.append('redirect_uri', `${config.metadataClientBaseUrl}/callback`);
+  authUrl.searchParams.append('response_type', 'code');
+  authUrl.searchParams.append('scope', 'openid profile email');
+  authUrl.searchParams.append('state', state);
+  authUrl.searchParams.append('code_challenge', codeChallenge);
+  authUrl.searchParams.append('code_challenge_method', 'S256');
+  // RFC 8707 Resource Indicators
+  authUrl.searchParams.append('resource', config.mcpServer.baseUrl);
+
+  return { authUrl: authUrl.toString(), codeVerifier, state };
+}
+
+// Handle the callback from the authorization server
+async function handleCallback(code, authServerInfo, metadataUrl, codeVerifier) {
+  const { authServerMetadata } = authServerInfo;
+
+  if (!authServerMetadata.token_endpoint) {
+    throw new Error('Token endpoint not found in server metadata');
+  }
+
+  if (!codeVerifier) {
+    throw new Error('Code verifier not found — session may have expired');
+  }
+
+  const config = require('../shared/config');
+
+  // Exchange code for tokens using standard token endpoint
+  // Use the metadata URL as client_id — the proxy handles CIMD resolution
+  const tokenResponse = await axios.post(
+    authServerMetadata.token_endpoint,
+    querystring.stringify({
+      grant_type: 'authorization_code',
+      client_id: metadataUrl,
+      redirect_uri: `${config.metadataClientBaseUrl}/callback`,
+      code,
+      code_verifier: codeVerifier,
+      resource: config.mcpServer.baseUrl
+    }),
+    { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }
+  );
+
+  const tokens = tokenResponse.data;
+  if (tokens.expires_in) {
+    tokens.expires_at = Date.now() + (tokens.expires_in * 1000);
+  }
+
+  return tokens;
+}
+
+// Refresh an access token
+async function refreshToken(refreshTokenValue, authServerInfo, metadataUrl) {
+  const { authServerMetadata } = authServerInfo;
+
+  if (!authServerMetadata.token_endpoint) {
+    throw new Error('Token endpoint not found in server metadata');
+  }
+
+  const tokenResponse = await axios.post(
+    authServerMetadata.token_endpoint,
+    querystring.stringify({
+      grant_type: 'refresh_token',
+      client_id: metadataUrl,
+      refresh_token: refreshTokenValue
+    }),
+    { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }
+  );
+
+  const tokens = tokenResponse.data;
+  if (tokens.expires_in) {
+    tokens.expires_at = Date.now() + (tokens.expires_in * 1000);
+  }
+  if (!tokens.refresh_token && refreshTokenValue) {
+    tokens.refresh_token = refreshTokenValue;
+  }
+
+  return tokens;
+}
+
+module.exports = {
+  initiateAuthFlow,
+  handleCallback,
+  refreshToken
+};

--- a/src/metadata-client/client-metadata.json
+++ b/src/metadata-client/client-metadata.json
@@ -1,0 +1,9 @@
+{
+  "client_id": "http://localhost:3003/client-metadata.json",
+  "redirect_uris": ["http://localhost:3003/callback"],
+  "client_name": "mcp-oauth-demo-metadata-client",
+  "client_uri": "http://localhost:3003",
+  "grant_types": ["authorization_code"],
+  "response_types": ["code"],
+  "token_endpoint_auth_method": "none"
+}

--- a/src/metadata-client/discovery.js
+++ b/src/metadata-client/discovery.js
@@ -1,0 +1,145 @@
+const axios = require('axios');
+
+/**
+ * Fetch authorization server metadata using spec-compliant well-known endpoint probing.
+ * Per MCP spec (2025-11-25), clients MUST try multiple well-known endpoints in priority order.
+ * If the URL is already a well-known endpoint, fetch it directly first.
+ * @param {string} authServerUrl - The authorization server URL from PRM
+ * @returns {Promise<Object>} The authorization server metadata
+ */
+async function fetchAuthServerMetadata(authServerUrl) {
+  const parsed = new URL(authServerUrl);
+
+  // If the PRM already gave us a well-known URL, try it directly first
+  if (parsed.pathname.includes('/.well-known/')) {
+    try {
+      console.log(`Fetching auth server metadata from well-known URL: ${authServerUrl}`);
+      const response = await axios.get(authServerUrl);
+      return response.data;
+    } catch (err) {
+      console.log(`Direct well-known fetch failed: ${err.message}, falling back to probing`);
+    }
+  }
+
+  // Extract issuer components for probing
+  const origin = parsed.origin;
+  const pathComponent = parsed.pathname === '/' ? '' : parsed.pathname;
+
+  // Build ordered list of well-known endpoints to try (per MCP spec)
+  const endpoints = pathComponent
+    ? [
+        // With path: try OAuth 2.0 AS Metadata with path insertion first
+        `${origin}/.well-known/oauth-authorization-server${pathComponent}`,
+        `${origin}/.well-known/openid-configuration${pathComponent}`,
+        `${origin}${pathComponent}/.well-known/openid-configuration`
+      ]
+    : [
+        // Without path: simpler probing
+        `${origin}/.well-known/oauth-authorization-server`,
+        `${origin}/.well-known/openid-configuration`
+      ];
+
+  for (const endpoint of endpoints) {
+    try {
+      console.log(`Probing auth server metadata at: ${endpoint}`);
+      const response = await axios.get(endpoint);
+      console.log(`Auth server metadata found at: ${endpoint}`);
+      return response.data;
+    } catch (err) {
+      console.log(`Probe failed for ${endpoint}: ${err.message}`);
+    }
+  }
+
+  throw new Error(`Could not discover authorization server metadata from: ${authServerUrl}`);
+}
+
+/**
+ * Perform MCP Server discovery with CIMD capability detection
+ * @param {string} mcpServerUrl - The URL of the MCP server
+ * @returns {Promise<Object>} - Authorization server info with CIMD support flag
+ */
+async function discovery(mcpServerUrl) {
+  try {
+    console.log(`Making initial request to MCP server: ${mcpServerUrl}`);
+
+    // Make a request to the MCP server that will return a 401
+    await axios.get(`${mcpServerUrl}/v1/contexts`);
+
+    // If we get here, something is wrong - we expected a 401
+    throw new Error('Expected 401 response not received from MCP server');
+  } catch (error) {
+    // Expected 401 error with WWW-Authenticate header
+    if (error.response && error.response.status === 401) {
+      const wwwAuthHeader = error.response.headers['www-authenticate'];
+
+      if (!wwwAuthHeader) {
+        throw new Error('WWW-Authenticate header missing from 401 response');
+      }
+
+      console.log('Received WWW-Authenticate header:', wwwAuthHeader);
+
+      // Extract resource_metadata URL from the header
+      const resourceMetadataMatch = wwwAuthHeader.match(/resource_metadata="([^"]+)"/);
+
+      if (!resourceMetadataMatch) {
+        throw new Error('resource_metadata not found in WWW-Authenticate header');
+      }
+
+      const resourceMetadataUrl = resourceMetadataMatch[1];
+      const fullResourceMetadataUrl = resourceMetadataUrl.startsWith('http')
+        ? resourceMetadataUrl
+        : `${mcpServerUrl}${resourceMetadataUrl}`;
+
+      console.log(`Discovered resource metadata URL: ${fullResourceMetadataUrl}`);
+
+      // Fetch the resource metadata
+      const resourceMetadataResponse = await axios.get(fullResourceMetadataUrl);
+      const resourceMetadata = resourceMetadataResponse.data;
+
+      if (!resourceMetadata.authorization_servers || resourceMetadata.authorization_servers.length === 0) {
+        throw new Error('No authorization servers found in resource metadata');
+      }
+
+      // Use the first authorization server
+      const authServerUrl = resourceMetadata.authorization_servers[0];
+      console.log(`Discovered authorization server: ${authServerUrl}`);
+
+      // Fetch the authorization server metadata using spec-compliant well-known probing
+      // MCP spec requires trying multiple endpoints in priority order
+      const authServerMetadata = await fetchAuthServerMetadata(authServerUrl);
+
+      try {
+        // Check for CIMD support
+        const cimdSupported = authServerMetadata.client_id_metadata_document_supported === true;
+        console.log(`Client ID Metadata Document support: ${cimdSupported}`);
+
+        if (!cimdSupported) {
+          throw new Error('Authorization server does not support Client ID Metadata Documents. ' +
+            'Check that client_id_metadata_document_supported is advertised in the auth server metadata.');
+        }
+
+        console.log('Authorization Server Metadata:', authServerMetadata);
+
+        return {
+          resourceMetadata,
+          authServerMetadata,
+          authServerUrl,
+          cimdSupported
+        };
+      } catch (authServerError) {
+        if (authServerError.message.includes('does not support Client ID')) {
+          throw authServerError;
+        }
+        console.error('Error fetching authorization server metadata:', authServerError.message);
+        throw new Error(`Failed to fetch authorization server metadata: ${authServerError.message}`);
+      }
+    } else {
+      console.error('Unexpected error during discovery:', error);
+      throw new Error(`Unexpected response from MCP server: ${error.message}`);
+    }
+  }
+}
+
+module.exports = {
+  discovery
+};

--- a/src/metadata-client/index.js
+++ b/src/metadata-client/index.js
@@ -1,0 +1,158 @@
+const express = require('express');
+const session = require('express-session');
+const { discovery } = require('./discovery');
+const { initiateAuthFlow, handleCallback, refreshToken } = require('./auth-flow');
+const { getMcpData } = require('./mcp-api');
+const config = require('../shared/config');
+
+const app = express();
+const PORT = process.env.METADATA_CLIENT_PORT || 3003;
+const CLIENT_URL = process.env.METADATA_CLIENT_URL || `http://localhost:${PORT}`;
+
+// The metadata URL is this client's identity (client_id)
+const METADATA_URL = `${CLIENT_URL}/client-metadata.json`;
+
+// Middleware
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+app.use(session({
+  secret: 'mcp-oauth-metadata-client-secret',
+  resave: false,
+  saveUninitialized: true,
+  cookie: { secure: false } // Set to true in production with HTTPS
+}));
+
+// Serve the Client ID Metadata Document
+// This URL IS the client_id — the authorization server fetches it to learn about this client
+app.get('/client-metadata.json', (req, res) => {
+  const metadata = require('./client-metadata.json');
+  // Ensure client_id matches the actual serving URL
+  metadata.client_id = METADATA_URL;
+  metadata.redirect_uris = [`${CLIENT_URL}/callback`];
+  metadata.client_uri = CLIENT_URL;
+  res.setHeader('Content-Type', 'application/json');
+  res.json(metadata);
+});
+
+// Home page
+app.get('/', (req, res) => {
+  const isAuthenticated = req.session.tokens && req.session.tokens.access_token;
+
+  res.send(`
+    <h1>MCP OAuth 2.1 Client ID Metadata Document (CIMD) Client</h1>
+    <p><strong>Client Identity (Metadata URL):</strong> <a href="${METADATA_URL}">${METADATA_URL}</a></p>
+    <p>This client uses a <em>Client ID Metadata Document</em> as its identity.
+    Instead of pre-registered credentials or Dynamic Client Registration,
+    the client publishes its OAuth metadata at a URL which becomes its <code>client_id</code>.
+    The authorization server transparently fetches and validates this document.</p>
+    ${isAuthenticated
+      ? '<p>Status: Authenticated</p>'
+      : '<p>Status: Not authenticated</p>'}
+    <div>
+      ${isAuthenticated
+        ? '<a href="/mcp-data"><button>Fetch MCP Data</button></a>'
+        : '<a href="/login"><button>Log in</button></a>'}
+      ${isAuthenticated
+        ? '<a href="/logout"><button>Log out</button></a>'
+        : ''}
+    </div>
+  `);
+});
+
+// Initiate login — standard OAuth flow using metadata URL as client_id
+app.get('/login', async (req, res) => {
+  try {
+    // Discover the MCP server and authorization server
+    const authServerInfo = await discovery(config.mcpServer.baseUrl);
+
+    // Store discovered info in session
+    req.session.authServerInfo = authServerInfo;
+
+    // Initiate auth flow using metadata URL as client_id
+    // No custom registration step — the authorization server handles CIMD transparently
+    console.log(`Starting OAuth flow with client_id: ${METADATA_URL}`);
+    const { authUrl, codeVerifier, state } = await initiateAuthFlow(authServerInfo, METADATA_URL);
+
+    // Store PKCE and state in session (not global) for concurrent user safety
+    req.session.codeVerifier = codeVerifier;
+    req.session.authState = state;
+
+    // Redirect to the authorization server
+    res.redirect(authUrl);
+  } catch (error) {
+    console.error('Error starting auth flow:', error);
+    res.status(500).send(`Error starting authentication: ${error.message}`);
+  }
+});
+
+// OAuth callback handler
+app.get('/callback', async (req, res) => {
+  const { code, state } = req.query;
+  const { authServerInfo, codeVerifier, authState } = req.session;
+
+  if (!code || !authServerInfo) {
+    return res.status(400).send('Missing authorization code or server info');
+  }
+
+  // Validate state parameter for CSRF protection
+  if (!state || state !== authState) {
+    return res.status(400).send('Invalid state parameter — possible CSRF attack');
+  }
+
+  try {
+    const tokens = await handleCallback(code, authServerInfo, METADATA_URL, codeVerifier);
+    req.session.tokens = tokens;
+    res.redirect('/');
+  } catch (error) {
+    console.error('Error handling callback:', error);
+    res.status(500).send(`Error exchanging code for token: ${error.message}`);
+  }
+});
+
+// Fetch MCP data
+app.get('/mcp-data', async (req, res) => {
+  const { tokens, authServerInfo } = req.session;
+
+  if (!tokens || !tokens.access_token || !authServerInfo) {
+    return res.redirect('/login');
+  }
+
+  try {
+    // Check if token is expired and refresh if needed
+    if (tokens.expires_at && Date.now() > tokens.expires_at) {
+      console.log('Access token expired. Refreshing...');
+      const newTokens = await refreshToken(tokens.refresh_token, authServerInfo, METADATA_URL);
+      req.session.tokens = newTokens;
+    }
+
+    const mcpData = await getMcpData(tokens.access_token);
+
+    res.send(`
+      <h1>MCP Data from CIMD Client</h1>
+      <p><strong>Client Identity (Metadata URL):</strong> ${METADATA_URL}</p>
+      <pre>${JSON.stringify(mcpData, null, 2)}</pre>
+      <a href="/"><button>Back to Home</button></a>
+    `);
+  } catch (error) {
+    console.error('Error fetching MCP data:', error);
+
+    if (error.response && error.response.status === 401) {
+      return res.redirect('/login');
+    }
+
+    res.status(500).send(`Error fetching MCP data: ${error.message}`);
+  }
+});
+
+// Logout
+app.get('/logout', (req, res) => {
+  req.session.destroy();
+  res.redirect('/');
+});
+
+// Start server
+app.listen(PORT, () => {
+  console.log(`MCP CIMD Client running on port ${PORT}`);
+  console.log(`Client ID Metadata Document served at: ${METADATA_URL}`);
+  console.log(`Visit http://localhost:${PORT} to start`);
+});

--- a/src/metadata-client/mcp-api.js
+++ b/src/metadata-client/mcp-api.js
@@ -1,0 +1,22 @@
+const axios = require('axios');
+const config = require('../shared/config');
+
+async function getMcpData(accessToken) {
+  try {
+    const response = await axios.get(`${config.mcpServer.baseUrl}/v1/contexts`, {
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'MCP-Protocol-Version': '2025-11-25'
+      }
+    });
+
+    return response.data;
+  } catch (error) {
+    console.error('Error calling MCP API:', error.message);
+    throw error;
+  }
+}
+
+module.exports = {
+  getMcpData
+};

--- a/src/metadata-client/package-lock.json
+++ b/src/metadata-client/package-lock.json
@@ -1,0 +1,1075 @@
+{
+  "name": "mcp-oauth2-aws-cognito-metadata-client",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mcp-oauth2-aws-cognito-metadata-client",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.9.0",
+        "crypto": "^1.0.1",
+        "dotenv": "^16.5.0",
+        "express": "^5.1.0",
+        "express-session": "^1.18.1"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
+      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in.",
+      "license": "ISC"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-session": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.19.0.tgz",
+      "integrity": "sha512-0csaMkGq+vaiZTmSMMGkfdCOabYv192VbytFypcvI0MANrp+4i/7yEkJ0sbAEhycQjntaKGzYfjfXQyVb7BHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "~0.7.2",
+        "cookie-signature": "~1.0.7",
+        "debug": "~2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.1.0",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "~5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/express-session/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express-session/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/src/metadata-client/package.json
+++ b/src/metadata-client/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "mcp-oauth2-aws-cognito-metadata-client",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "Empires Security Labs",
+  "license": "MIT",
+  "description": "Client ID Metadata Document (CIMD) client for MCP OAuth 2.1",
+  "dependencies": {
+    "axios": "^1.9.0",
+    "crypto": "^1.0.1",
+    "dotenv": "^16.5.0",
+    "express": "^5.1.0",
+    "express-session": "^1.18.1"
+  }
+}

--- a/src/shared/config.js
+++ b/src/shared/config.js
@@ -19,6 +19,9 @@ module.exports = {
   
   // Auto Client Base URL
   autoClientBaseUrl: process.env.AUTO_CLIENT_URL || 'http://localhost:3002',
+
+  // Metadata Client Base URL (CIMD)
+  metadataClientBaseUrl: process.env.METADATA_CLIENT_URL || 'http://localhost:3003',
   
   // Dynamic Client Registration endpoint
   dcrEndpoint: process.env.DCR_ENDPOINT || 'https://api-gateway-url/v1/register',
@@ -53,7 +56,7 @@ module.exports = {
       const userPoolId = process.env.COGNITO_USER_POOL_ID;
       
       if (!region || !userPoolId) {
-        console.warn('Missing Cognito region or user pool ID for constructing auth server URL');
+        // Not all services need Cognito config (e.g., metadata-client discovers dynamically)
         return '';
       }
       


### PR DESCRIPTION
Add CIMD support and spec compliance fixes

New: Client ID Metadata Documents (CIMD)
- metadata-client using URL as client_id
- cimd-validator with ssrf and metadata checks
- authorization proxy for transparent cimd bridging
- cimd sequence diagram

Fixes: MCP 2025-11-25 spec compliance
- scope added to www-authenticate 401 headers
- redirect_uri validated in token proxy
- client_name required in cimd metadata validation
- pkce and state moved to session storage
- state parameter validated on oauth callback
- well-known endpoint probing in discovery
- non-standard scope removed from client metadata

Infra and docs
- deploy script generates metadata-client env
- readme updated for three client methods
- architecture and setup guides updated
